### PR TITLE
add documentation to core types

### DIFF
--- a/src/core/components.rs
+++ b/src/core/components.rs
@@ -7,17 +7,28 @@ use crate::{
     supervisor::messaging::*,
 };
 
-// A trait to encapsulate types needed for a blox
+/// A trait to encapsulate types needed for a blox
 pub trait Components {
+    /// The extended state of the blox.
+    /// Different from the state enum in that
+    /// ExtendedState is for holding data while StateEnum isn't.
     type ExtendedState: ExtendedState;
+    /// The state enum of the blox.
+    /// Represents the different states the blox can be in.
     type States: StateEnum + Default;
+    /// The message set of the blox.
     type MessageSet: MessageSet;
+    /// The receivers of the blox
+    /// The blox should receive messages from the receivers in this type.
     type Receivers;
+    /// The handles of the blox
+    /// The blox should hand out handles of this type to other bloxes
+    /// so they can send messages to the blox.
     type Handles;
 }
 
-//The main blox struct.  Bloxes are differentiated by their components
-//Anything that all Bloxes should have is stored here
+///The main blox struct.  Bloxes are differentiated by their components
+///Anything that all Bloxes should have is stored here
 pub struct Blox<C: Components> {
     pub handle: StandardMessageHandle,
     pub state_machine: StateMachine<C>,
@@ -45,9 +56,13 @@ where
     }
 }
 
-//Implement Runnable or RunnableLocal depending on if the blox implements Send
+/// The core engine that runs the blox. The blox should receive messages from the receivers in the `run` method.
+/// Implement Runnable or RunnableLocal depending on if the blox implements Send
 pub trait Runnable<B: Components> {
+    /// The main loop of the blox. Receive messages from the receivers and process them here.
     fn run(self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+    /// Convert the blox into a request to be sent to the supervisor.
     fn into_request(self: Box<Self>) -> SupervisorPayload
     where
         Self: Send + 'static,
@@ -61,8 +76,12 @@ pub trait Runnable<B: Components> {
     }
 }
 
+/// The non-send counterpart to Runnable.
 pub trait RunnableLocal<B: Components> {
+    /// The main loop of the blox. Receive messages from the receivers and process them here.
     fn run_local(self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + 'static>>;
+
+    /// Convert the blox into a request to be sent to the supervisor.
     fn into_request(self: Box<Self>) -> SupervisorLocalPayload
     where
         Self: Send + 'static,

--- a/src/core/messaging.rs
+++ b/src/core/messaging.rs
@@ -28,6 +28,7 @@ pub struct RawPayload {
 }
 
 /// Marker trait for message sets
+/// Blox's message enum should implement this trait to specify the messages they can send and receive.
 pub trait MessageSet {}
 
 /// Handle type that corresponds to a specific message type

--- a/src/core/state_machine.rs
+++ b/src/core/state_machine.rs
@@ -21,10 +21,13 @@ pub enum Transition<T, M> {
     Parent(M),
 }
 
+/// The state machine that coordinates the state transitions of a blox.
 pub struct StateMachine<C: Components> {
+    /// The state the blox is currently in.
     pub current_state: C::States,
-    // ExtendedState stored here to be passed to each state
+    // ExtendedState stored here to be passed to each state.
     pub extended_state: C::ExtendedState,
+    /// The handles of the blox.
     pub self_handles: C::Handles,
 }
 
@@ -122,21 +125,30 @@ where
     }
 }
 
+/// A trait for the states of a blox.
+/// All states must have a parent state.
+/// All states must implement the `handle_message` and `parent` methods.
 pub trait State<C: Components>: fmt::Debug + 'static {
-    // Default on_entry and on_exit functions do nothing, only need to be overridden if needed
+    /// Called when the state is entered. Will need to be
+    /// called manually on the StateEnum's inner types.
     fn on_entry(&self, _state_machine: &mut StateMachine<C>) {
         trace!("State on_entry: {:?}", self);
     }
 
+    /// Called when the state is entered. Will need to be
+    /// called manually on the StateEnum's inner types.
     fn on_exit(&self, _state_machine: &mut StateMachine<C>) {
         trace!("State on_exit: {:?}", self);
     }
 
-    // All states must have a parent state
+    /// All states must have a parent state
+    /// Used when changing states.
     fn parent(&self) -> C::States {
         panic!("No parent for this state");
     }
 
+    /// Handles messages for the state.
+    /// Will need to be called manually on the StateEnum's inner types to be useful.
     fn handle_message(
         &self,
         state_machine: &mut StateMachine<C>,


### PR DESCRIPTION
This is a small PR that adds documentation on the core types. What they do and how to use them. Let me know your thoughts.