### PR TITLE
Add bloxide visualizer tools: source-driven spec export + fullstack web UI

### DIFF
--- a/tools/bloxide-visualizer/Cargo.toml
+++ b/tools/bloxide-visualizer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bloxide-visualizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dioxus = { version = "0.7.6", features = ["fullstack"] }
+dioxus-fullstack = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+pulldown-cmark = "0.12"
+
+# Server-only dependencies for workspace scanning
+bloxide-viz-export = { path = "../bloxide-viz-export", optional = true }
+
+[features]
+web = ["dioxus/web"]
+server = ["dioxus/server", "dep:bloxide-viz-export"]
+
+[workspace]

--- a/tools/bloxide-visualizer/Dioxus.toml
+++ b/tools/bloxide-visualizer/Dioxus.toml
@@ -1,0 +1,21 @@
+[application]
+name = "Bloxide Visualizer"
+default_platform = "web"
+out_dir = "dist"
+asset_dir = "assets"
+
+[web.app]
+title = "Bloxide Visualizer"
+base_path = "/"
+
+[web.watcher]
+watch_path = ["src", "assets"]
+reload_html = true
+
+[web.resource.dev]
+style = []
+script = []
+
+[web.resource.release]
+style = []
+script = []

--- a/tools/bloxide-visualizer/serve.sh
+++ b/tools/bloxide-visualizer/serve.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Serve the Bloxide Visualizer in release mode on port 1420
+# Usage: ./serve.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Serving Bloxide Visualizer..."
+echo "  Mode:    release"
+echo "  Port:    1420"
+echo "  URL:     http://localhost:1420"
+echo ""
+
+dx serve --port 1420 --release --debug-symbols false

--- a/tools/bloxide-visualizer/src/data.rs
+++ b/tools/bloxide-visualizer/src/data.rs
@@ -1,0 +1,105 @@
+use crate::model::BloxSpec;
+use crate::parser::parse_spec;
+
+pub fn parse_json_spec(name: &str, json: &str) -> Result<BloxSpec, String> {
+    let mut spec: BloxSpec =
+        serde_json::from_str(json).map_err(|e| format!("Failed to parse JSON: {}", e))?;
+    // Override name from parameter in case the JSON has a different one
+    spec.name = name.to_string();
+    Ok(spec)
+}
+
+pub fn load_specs() -> Vec<BloxSpec> {
+    let counter_md = include_str!("../../../spec/bloxes/counter.md");
+    let ping_md = include_str!("../../../spec/bloxes/ping.md");
+    let pong_md = include_str!("../../../spec/bloxes/pong.md");
+    let pool_md = include_str!("../../../spec/bloxes/pool.md");
+    let worker_md = include_str!("../../../spec/bloxes/worker.md");
+
+    vec![
+        parse_spec("Counter", counter_md),
+        parse_spec("Ping", ping_md),
+        parse_spec("Pong", pong_md),
+        parse_spec("Pool", pool_md),
+        parse_spec("Worker", worker_md),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_counter() {
+        let md = include_str!("../../../spec/bloxes/counter.md");
+        let spec = parse_spec("Counter", md);
+
+        println!("States: {:?}", spec.states);
+        println!("Events: {:?}", spec.events);
+        println!("Handlers: {:?}", spec.handlers);
+        println!("EntryExit: {:?}", spec.entry_exit);
+
+        // Should have at least Ready and Done states
+        assert!(spec.states.iter().any(|s| s.name == "Ready"));
+        assert!(spec.states.iter().any(|s| s.name == "Done"));
+
+        // Should have CounterMsg::Tick event
+        assert!(spec
+            .events
+            .iter()
+            .any(|e| e.full_name == "CounterMsg::Tick"));
+
+        // Ready should have a handler for Tick
+        assert!(spec
+            .handlers
+            .iter()
+            .any(|h| h.state == "Ready" && h.event == "CounterMsg::Tick"));
+    }
+
+    #[test]
+    fn test_parse_ping() {
+        let md = include_str!("../../../spec/bloxes/ping.md");
+        let spec = parse_spec("Ping", md);
+
+        println!("States: {:?}", spec.states);
+        println!("Events: {:?}", spec.events);
+        println!("Handlers: {:?}", spec.handlers);
+
+        // Should have key states
+        assert!(spec.states.iter().any(|s| s.name == "Operating"));
+        assert!(spec.states.iter().any(|s| s.name == "Active"));
+        assert!(spec.states.iter().any(|s| s.name == "Paused"));
+        assert!(spec.states.iter().any(|s| s.name == "Done"));
+        assert!(spec.states.iter().any(|s| s.name == "Error"));
+
+        // Should have PingPongMsg events
+        assert!(spec
+            .events
+            .iter()
+            .any(|e| e.full_name == "PingPongMsg::Pong"));
+        assert!(spec
+            .events
+            .iter()
+            .any(|e| e.full_name == "PingPongMsg::Resume"));
+
+        // Active should have handler for Pong
+        assert!(spec
+            .handlers
+            .iter()
+            .any(|h| h.state == "Active" && h.event == "PingPongMsg::Pong"));
+    }
+
+    #[test]
+    fn test_parse_json_counter() {
+        // This test verifies that JSON exported by bloxide-viz-export can be loaded
+        // Run `cargo run` in ../bloxide-viz-export to generate the fixture first.
+        let json = std::fs::read_to_string("../bloxide-viz-export/bloxide-viz-output/counter.json");
+        if let Ok(json) = json {
+            let spec = parse_json_spec("Counter", &json).unwrap();
+            assert!(spec.states.iter().any(|s| s.name == "Ready"));
+            assert!(spec.states.iter().any(|s| s.name == "Done"));
+            // Should have at least one handler extracted from transitions!
+            assert!(!spec.handlers.is_empty());
+        }
+    }
+}

--- a/tools/bloxide-visualizer/src/main.rs
+++ b/tools/bloxide-visualizer/src/main.rs
@@ -1,0 +1,505 @@
+mod data;
+mod model;
+mod parser;
+
+use dioxus::prelude::*;
+use dioxus_fullstack::server;
+use dioxus_fullstack::ServerFnError;
+use model::*;
+
+#[cfg(feature = "server")]
+use bloxide_viz_export;
+
+/// Server function: scan a workspace path and return all discovered blox specs.
+#[server(endpoint = "api/scan")]
+async fn scan_workspace(path: String) -> Result<Vec<BloxSpec>, ServerFnError> {
+    #[cfg(feature = "server")]
+    {
+        let workspace = std::path::Path::new(&path);
+        if !workspace.exists() {
+            return Err(ServerFnError::ServerError {
+                message: format!("Path does not exist: {}", path),
+                code: 400,
+                details: None,
+            });
+        }
+        match bloxide_viz_export::export_workspace(workspace) {
+            Ok(specs) => {
+                // Convert from bloxide_viz_export::BloxSpec to our model::BloxSpec via JSON
+                let json =
+                    serde_json::to_string(&specs).map_err(|e| ServerFnError::ServerError {
+                        message: format!("JSON serialization failed: {}", e),
+                        code: 500,
+                        details: None,
+                    })?;
+                let specs: Vec<BloxSpec> =
+                    serde_json::from_str(&json).map_err(|e| ServerFnError::ServerError {
+                        message: format!("JSON deserialization failed: {}", e),
+                        code: 500,
+                        details: None,
+                    })?;
+                Ok(specs)
+            }
+            Err(e) => Err(ServerFnError::ServerError {
+                message: e,
+                code: 500,
+                details: None,
+            }),
+        }
+    }
+    #[cfg(not(feature = "server"))]
+    {
+        let _ = path;
+        Err(ServerFnError::ServerError {
+            message: "Server feature not enabled".to_string(),
+            code: 500,
+            details: None,
+        })
+    }
+}
+
+fn main() {
+    dioxus::launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    let mut specs = use_signal(|| data::load_specs());
+    let mut selected_spec = use_signal(|| 0usize);
+    let mut selected_cell = use_signal(|| None::<(String, String)>);
+
+    let spec = &specs.read()[selected_spec.read().clone()];
+
+    let message_sets = spec.message_sets_for_events();
+    let leaf_states = spec.leaf_states();
+
+    rsx! {
+        div {
+            style: "font-family: system-ui, -apple-system, sans-serif; padding: 20px; background: #f5f5f5; min-height: 100vh;",
+            h1 { style: "margin: 0 0 20px 0; color: #333;", "Bloxide Visualizer" }
+            div {
+                style: "display: flex; gap: 10px; margin-bottom: 20px; align-items: center;",
+                for (idx, s) in specs.read().iter().enumerate() {
+                    button {
+                        style: if selected_spec.read().clone() == idx {
+                            "padding: 8px 16px; background: #2563eb; color: white; border: none; border-radius: 4px; cursor: pointer;"
+                        } else {
+                            "padding: 8px 16px; background: white; color: #333; border: 1px solid #ddd; border-radius: 4px; cursor: pointer;"
+                        },
+                        onclick: move |_| selected_spec.set(idx),
+                        "{s.name}"
+                    }
+                }
+                // Workspace scan input
+                WorkspaceScanner {
+                    specs: specs,
+                    selected_spec: selected_spec,
+                    selected_cell: selected_cell,
+                }
+                label {
+                    style: "padding: 8px 16px; background: #10b981; color: white; border: none; border-radius: 4px; cursor: pointer; display: inline-block; font-size: 14px; font-family: system-ui, sans-serif;",
+                    "Import .md / .json"
+                    input {
+                        r#type: "file",
+                        accept: ".md,.json",
+                        style: "display: none;",
+                        onchange: move |evt| {
+                            async move {
+                                for file in evt.files() {
+                                    if let Ok(content) = file.read_string().await {
+                                        let name = {
+                                            let n = file.name()
+                                                .trim_end_matches(".md")
+                                                .trim_end_matches(".MD")
+                                                .trim_end_matches(".json")
+                                                .trim_end_matches(".JSON")
+                                                .to_string();
+                                            if n.is_empty() { "Imported".to_string() } else { n }
+                                        };
+                                        let imported = if file.name().ends_with(".json") || file.name().ends_with(".JSON") {
+                                            match crate::data::parse_json_spec(&name, &content) {
+                                                Ok(spec) => spec,
+                                                Err(_e) => {
+                                                    // On JSON parse failure, fall back to markdown parser
+                                                    crate::parser::parse_spec(&name, &content)
+                                                }
+                                            }
+                                        } else {
+                                            crate::parser::parse_spec(&name, &content)
+                                        };
+                                        let new_idx = {
+                                            let mut specs_guard = specs.write();
+                                            specs_guard.push(imported);
+                                            specs_guard.len() - 1
+                                        };
+                                        selected_cell.set(None);
+                                        selected_spec.set(new_idx);
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            }
+            div {
+                style: "display: flex; gap: 20px; justify-content: center; align-items: flex-start;",
+                // Main grid
+                div {
+                    style: "flex: 0 1 auto; max-width: 100%;",
+                    h2 { style: "margin: 0 0 10px 0; color: #333; text-align: center;", "{spec.name} Heatmap" }
+                    div {
+                        style: "background: white; border-radius: 8px; padding: 16px; overflow-x: auto; display: flex; justify-content: center;",
+                        HeatmapGrid {
+                            spec: spec.clone(),
+                            message_sets,
+                            leaf_states: leaf_states.iter().map(|s| (*s).clone()).collect(),
+                            selected_cell: selected_cell,
+                        }
+                    }
+                }
+                // Side panel
+                if let Some((state, event)) = selected_cell.read().clone() {
+                    SidePanel {
+                        spec: spec.clone(),
+                        state,
+                        event,
+                        on_close: move |_| selected_cell.set(None),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn WorkspaceScanner(
+    specs: Signal<Vec<BloxSpec>>,
+    selected_spec: Signal<usize>,
+    selected_cell: Signal<Option<(String, String)>>,
+) -> Element {
+    let mut workspace_path = use_signal(|| "/home/bboganware/repos/bloxide".to_string());
+    let mut scan_status = use_signal(|| None::<String>);
+
+    rsx! {
+        div {
+            style: "display: flex; gap: 8px; align-items: center;",
+            input {
+                r#type: "text",
+                value: "{workspace_path}",
+                placeholder: "Path to workspace...",
+                style: "padding: 6px 12px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 14px; min-width: 240px;",
+                oninput: move |evt| workspace_path.set(evt.value()),
+            }
+            button {
+                style: "padding: 8px 16px; background: #6366f1; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px;",
+                onclick: move |_| {
+                    async move {
+                        scan_status.set(Some("Scanning...".to_string()));
+                        match scan_workspace(workspace_path()).await {
+                            Ok(new_specs) => {
+                                let count = new_specs.len();
+                                {
+                                    let mut specs_guard = specs.write();
+                                    for spec in new_specs {
+                                        if !specs_guard.iter().any(|s| s.name == spec.name) {
+                                            specs_guard.push(spec);
+                                        }
+                                    }
+                                }
+                                selected_cell.set(None);
+                                selected_spec.set(specs.read().len().saturating_sub(count.max(1)));
+                                scan_status.set(Some(format!("Found {} blox crate(s)", count)));
+                            }
+                            Err(e) => {
+                                scan_status.set(Some(format!("Error: {}", e)));
+                            }
+                        }
+                    }
+                },
+                "Scan workspace"
+            }
+            if let Some(status) = scan_status.read().clone() {
+                span {
+                    style: "font-size: 12px; color: #6b7280;",
+                    "{status}"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn HeatmapGrid(
+    spec: BloxSpec,
+    message_sets: Vec<MessageSet>,
+    leaf_states: Vec<State>,
+    selected_cell: Signal<Option<(String, String)>>,
+) -> Element {
+    let total_columns: usize = message_sets.iter().map(|ms| ms.variants.len()).sum();
+    let grid_template = format!(
+        "display: inline-grid; gap: 1px; background: #e5e7eb; border: 1px solid #d1d5db; border-radius: 4px; overflow: hidden; grid-template-columns: auto {};",
+        std::iter::repeat("minmax(100px, max-content)").take(total_columns).collect::<Vec<_>>().join(" ")
+    );
+
+    // Build header cells
+    let mut header_cells = Vec::new();
+    header_cells.push((
+        "".to_string(),
+        1usize,
+        "background: #f9fafb; padding: 8px; font-weight: bold; border-bottom: 1px solid #e5e7eb;"
+            .to_string(),
+    ));
+
+    for ms in &message_sets {
+        let span = ms.variants.len();
+        let style = format!(
+            "background: #f3f4f6; padding: 8px; font-weight: bold; font-size: 12px; color: #6b7280; text-align: center; border-bottom: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; grid-column: span {};",
+            span
+        );
+        header_cells.push((ms.name.clone(), span, style));
+    }
+
+    // Build sub-header cells
+    let mut subheader_cells = Vec::new();
+    subheader_cells.push(("State".to_string(), 1usize, "background: #f9fafb; padding: 8px; font-weight: bold; font-size: 12px; border-bottom: 1px solid #e5e7eb;".to_string()));
+
+    for ms in &message_sets {
+        for variant in &ms.variants {
+            subheader_cells.push((variant.clone(), 1usize, "background: #f9fafb; padding: 8px; font-weight: 600; font-size: 11px; color: #374151; text-align: center; border-bottom: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb;".to_string()));
+        }
+    }
+
+    // Build data rows
+    let mut data_rows = Vec::new();
+    for state in &leaf_states {
+        let kind_symbol = state.kind.symbol().to_string();
+        let state_style = "background: #f9fafb; padding: 6px 12px; font-weight: 600; font-size: 13px; color: #1f2937; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; white-space: nowrap;".to_string();
+
+        let mut cells = Vec::new();
+        for ms in &message_sets {
+            for variant in &ms.variants {
+                let event_full = format!("{}::{}", ms.name, variant);
+                let handler = spec.handler_for(&state.name, &event_full);
+
+                if let Some(h) = handler {
+                    let (bg_color, border_style) = match h.source {
+                        HandlerSource::Explicit => ("#dbeafe", "2px solid #2563eb"),
+                        HandlerSource::Inherited(_) => ("#fef3c7", "2px dashed #f59e0b"),
+                        HandlerSource::Dropped => ("#f3f4f6", "1px solid #e5e7eb"),
+                    };
+                    let is_dropped = h.source == HandlerSource::Dropped;
+                    let cell_state = state.name.clone();
+                    let cell_event = event_full.clone();
+                    let label = h.label.clone();
+
+                    let style = format!(
+                        "background: {}; padding: 6px 12px; text-align: center; cursor: pointer; border-bottom: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; min-height: 32px; display: flex; align-items: center; justify-content: center; border-left: {};",
+                        bg_color, border_style
+                    );
+
+                    cells.push((cell_state, cell_event, label, is_dropped, style));
+                } else {
+                    let style = "background: #f3f4f6; padding: 6px 12px; text-align: center; border-bottom: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; min-height: 32px; display: flex; align-items: center; justify-content: center;".to_string();
+                    cells.push((state.name.clone(), event_full, "∅".to_string(), true, style));
+                }
+            }
+        }
+
+        data_rows.push((state.name.clone(), kind_symbol, state_style, cells));
+    }
+
+    rsx! {
+        div {
+            style: "{grid_template}",
+
+            // Header row: message set names
+            for (text, _span, style) in header_cells {
+                div { style: "{style}", "{text}" }
+            }
+
+            // Sub-header row: individual event variants
+            for (text, _span, style) in subheader_cells {
+                div { style: "{style}", "{text}" }
+            }
+
+            // State rows
+            for (state_name, kind_symbol, state_style, cells) in data_rows {
+                div {
+                    style: "{state_style}",
+                    span { style: "margin-right: 4px; color: #9ca3af;", "{kind_symbol}" }
+                    "{state_name}"
+                }
+
+                for (cell_state, cell_event, label, is_dropped, style) in cells {
+                    div {
+                        style: "{style}",
+                        onclick: move |_| selected_cell.set(Some((cell_state.clone(), cell_event.clone()))),
+                        if is_dropped {
+                            span { style: "color: #9ca3af; font-size: 18px;", "∅" }
+                        } else {
+                            span { style: "font-size: 11px; color: #1f2937; font-weight: 500;", "{label}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn SidePanel(spec: BloxSpec, state: String, event: String, on_close: EventHandler<()>) -> Element {
+    let handler = spec.handler_for(&state, &event).cloned();
+    let state_info = spec.state_by_name(&state);
+    let entry_exit = spec.entry_exit.get(&state).cloned();
+
+    // Pre-compute all values before RSX
+    let state_kind_str = state_info.map(|s| format!("{:?}", s.kind));
+    let state_parent = state_info.and_then(|s| s.parent.clone());
+
+    let source_text = handler.as_ref().map(|h| match &h.source {
+        HandlerSource::Explicit => "This state's transitions".to_string(),
+        HandlerSource::Inherited(parent) => format!("Inherited from {parent}"),
+        HandlerSource::Dropped => "No handler — event dropped".to_string(),
+    });
+
+    let has_actions = handler
+        .as_ref()
+        .map(|h| !h.actions.is_empty())
+        .unwrap_or(false);
+    let actions = handler
+        .as_ref()
+        .map(|h| h.actions.clone())
+        .unwrap_or_default();
+
+    let has_guard = handler
+        .as_ref()
+        .map(|h| h.source != HandlerSource::Dropped)
+        .unwrap_or(false);
+    let guard_desc = handler.as_ref().map(|h| h.guard.description.clone());
+    let guard_branch_data: Vec<(String, String)> = handler
+        .as_ref()
+        .map(|h| {
+            h.guard
+                .branches
+                .iter()
+                .map(|b| (b.condition.clone(), b.target.display()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let target_disp = handler.as_ref().map(|h| h.target.display());
+
+    rsx! {
+        div {
+            style: "width: 380px; background: white; border-radius: 8px; padding: 20px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); max-height: 80vh; overflow-y: auto;",
+            div {
+                style: "display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;",
+                h3 { style: "margin: 0; color: #1f2937; font-size: 16px;", "{state} × {event}" }
+                button {
+                    style: "background: none; border: none; font-size: 20px; cursor: pointer; color: #6b7280;",
+                    onclick: move |_| on_close.call(()),
+                    "×"
+                }
+            }
+
+            if let Some(kind_str) = state_kind_str {
+                div {
+                    style: "margin-bottom: 16px; padding: 12px; background: #f9fafb; border-radius: 6px;",
+                    div { style: "font-size: 12px; color: #6b7280; margin-bottom: 4px;", "State Kind" }
+                    div { style: "font-weight: 600; color: #1f2937;", "{kind_str}" }
+                    if let Some(parent) = state_parent {
+                        div { style: "margin-top: 8px; font-size: 12px; color: #6b7280;", "Parent: {parent}" }
+                    }
+                }
+            }
+
+            if let Some(source) = source_text {
+                div {
+                    style: "margin-bottom: 16px;",
+                    div { style: "font-size: 12px; color: #6b7280; margin-bottom: 4px;", "Declared In" }
+                    div {
+                        style: "font-weight: 500; color: #1f2937;",
+                        "{source}"
+                    }
+                }
+            }
+
+            if has_actions {
+                div {
+                    style: "margin-bottom: 16px;",
+                    div { style: "font-size: 12px; color: #6b7280; margin-bottom: 8px;", "Actions (run before guard)" }
+                    for (idx, action) in actions.iter().enumerate() {
+                        div {
+                            style: "padding: 8px 12px; background: #eff6ff; border-radius: 4px; margin-bottom: 4px; font-size: 13px; color: #1e40af; font-family: monospace;",
+                            "{idx + 1}. {action}"
+                        }
+                    }
+                }
+            }
+
+            if has_guard {
+                if let Some(guard_desc) = guard_desc {
+                    div {
+                        style: "margin-bottom: 16px;",
+                        div { style: "font-size: 12px; color: #6b7280; margin-bottom: 8px;", "Guard (read-only, after actions)" }
+                        div {
+                            style: "padding: 12px; background: #fefce8; border-radius: 4px; font-size: 13px; color: #713f12; font-family: monospace; white-space: pre-wrap;",
+                            "{guard_desc}"
+                        }
+                        if !guard_branch_data.is_empty() {
+                            for (cond, target_disp) in &guard_branch_data {
+                                div {
+                                    style: "margin-top: 8px; padding: 8px; background: #fffbeb; border-radius: 4px; font-size: 12px;",
+                                    span { style: "color: #92400e;", "if {cond} → " }
+                                    span { style: "font-weight: 600; color: #92400e;", "{target_disp}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(target) = target_disp {
+                div {
+                    style: "margin-bottom: 16px;",
+                    div { style: "font-size: 12px; color: #6b7280; margin-bottom: 4px;", "Outcome" }
+                    div {
+                        style: "font-weight: 600; color: #1f2937;",
+                        "{target}"
+                    }
+                }
+            }
+
+            // Entry/Exit
+            if let Some(ee) = entry_exit {
+                div {
+                    style: "border-top: 1px solid #e5e7eb; padding-top: 16px;",
+                    if !ee.on_entry.is_empty() {
+                        div {
+                            style: "margin-bottom: 12px;",
+                            div { style: "font-size: 12px; color: #6b7280; margin-bottom: 4px;", "on_entry" }
+                            for action in &ee.on_entry {
+                                div {
+                                    style: "padding: 4px 8px; background: #f0fdf4; border-radius: 4px; margin-bottom: 4px; font-size: 12px; color: #166534; font-family: monospace;",
+                                    "{action}"
+                                }
+                            }
+                        }
+                    }
+                    if !ee.on_exit.is_empty() {
+                        div {
+                            style: "margin-bottom: 12px;",
+                            div { style: "font-size: 12px; color: #6b7280; margin-bottom: 4px;", "on_exit" }
+                            for action in &ee.on_exit {
+                                div {
+                                    style: "padding: 4px 8px; background: #fdf2f8; border-radius: 4px; margin-bottom: 4px; font-size: 12px; color: #9d174d; font-family: monospace;",
+                                    "{action}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/bloxide-visualizer/src/model.rs
+++ b/tools/bloxide-visualizer/src/model.rs
@@ -1,0 +1,158 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BloxSpec {
+    pub name: String,
+    pub states: Vec<State>,
+    pub events: Vec<Event>,
+    pub handlers: Vec<Handler>,
+    pub entry_exit: HashMap<String, EntryExit>,
+    pub message_sets: Vec<MessageSet>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct State {
+    pub name: String,
+    pub kind: StateKind,
+    pub parent: Option<String>,
+    pub description: String,
+    pub depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StateKind {
+    Leaf,
+    Composite,
+    Terminal,
+    Error,
+}
+
+impl StateKind {
+    pub fn is_leaf(&self) -> bool {
+        matches!(
+            self,
+            StateKind::Leaf | StateKind::Terminal | StateKind::Error
+        )
+    }
+
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            StateKind::Leaf => "",
+            StateKind::Composite => "◇",
+            StateKind::Terminal => "◆",
+            StateKind::Error => "◈",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Event {
+    pub message_set: String,
+    pub variant: String,
+    pub full_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageSet {
+    pub name: String,
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Handler {
+    pub state: String,
+    pub event: String,
+    pub label: String,
+    pub actions: Vec<String>,
+    pub guard: Guard,
+    pub target: Target,
+    pub source: HandlerSource,
+    pub on_entry: Vec<String>,
+    pub on_exit: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum HandlerSource {
+    Explicit,
+    Inherited(String), // from parent state name
+    Dropped,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Target {
+    Stay,
+    Transition(String),
+    Reset,
+}
+
+impl Target {
+    pub fn display(&self) -> String {
+        match self {
+            Target::Stay => "stay".to_string(),
+            Target::Transition(s) => s.clone(),
+            Target::Reset => "reset".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Guard {
+    pub description: String,
+    pub raw: String,
+    pub branches: Vec<GuardBranch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GuardBranch {
+    pub condition: String,
+    pub target: Target,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntryExit {
+    pub on_entry: Vec<String>,
+    pub on_exit: Vec<String>,
+}
+
+impl BloxSpec {
+    pub fn leaf_states(&self) -> Vec<&State> {
+        self.states.iter().filter(|s| s.kind.is_leaf()).collect()
+    }
+
+    pub fn composite_states(&self) -> Vec<&State> {
+        self.states
+            .iter()
+            .filter(|s| matches!(s.kind, StateKind::Composite))
+            .collect()
+    }
+
+    pub fn state_by_name(&self, name: &str) -> Option<&State> {
+        self.states.iter().find(|s| s.name == name)
+    }
+
+    pub fn handler_for(&self, state: &str, event: &str) -> Option<&Handler> {
+        self.handlers
+            .iter()
+            .find(|h| h.state == state && h.event == event)
+    }
+
+    pub fn events_for_set(&self, set_name: &str) -> Vec<&Event> {
+        self.events
+            .iter()
+            .filter(|e| e.message_set == set_name)
+            .collect()
+    }
+
+    pub fn message_sets_for_events(&self) -> Vec<MessageSet> {
+        let mut sets: HashMap<String, Vec<String>> = HashMap::new();
+        for event in &self.events {
+            sets.entry(event.message_set.clone())
+                .or_default()
+                .push(event.variant.clone());
+        }
+        sets.into_iter()
+            .map(|(name, variants)| MessageSet { name, variants })
+            .collect()
+    }
+}

--- a/tools/bloxide-visualizer/src/parser.rs
+++ b/tools/bloxide-visualizer/src/parser.rs
@@ -1,0 +1,575 @@
+use crate::model;
+use crate::model::*;
+use std::collections::HashMap;
+
+pub fn parse_spec(name: &str, markdown: &str) -> BloxSpec {
+    let mut states = Vec::new();
+    let mut events = Vec::new();
+    let mut handlers = Vec::new();
+    let mut entry_exit = HashMap::new();
+    let mut message_sets = Vec::new();
+
+    // Phase 1: Extract mermaid diagrams and section boundaries
+    let mut current_section = String::new();
+    let mut in_mermaid = false;
+    let mut mermaid_content = String::new();
+    let mut section_boundaries: Vec<(String, usize)> = Vec::new(); // (section_name, line_number)
+
+    for (line_num, line) in markdown.lines().enumerate() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("## ") {
+            current_section = trimmed.trim_start_matches("## ").trim().to_string();
+            section_boundaries.push((current_section.clone(), line_num));
+        }
+
+        if trimmed.starts_with("```mermaid") {
+            in_mermaid = true;
+            continue;
+        }
+        if trimmed.starts_with("```") && in_mermaid {
+            parse_mermaid(&mermaid_content, &mut states);
+            in_mermaid = false;
+            mermaid_content.clear();
+            continue;
+        }
+        if in_mermaid {
+            mermaid_content.push_str(line);
+            mermaid_content.push('\n');
+        }
+    }
+
+    // Phase 2: Parse tables line-by-line within each section
+    for i in 0..section_boundaries.len() {
+        let (section_name, start_line) = &section_boundaries[i];
+        let end_line = if i + 1 < section_boundaries.len() {
+            section_boundaries[i + 1].1
+        } else {
+            markdown.lines().count()
+        };
+
+        let section_lines: Vec<&str> = markdown
+            .lines()
+            .skip(*start_line)
+            .take(end_line - start_line)
+            .collect();
+
+        // Find and parse tables in this section
+        parse_tables_in_section(
+            section_name,
+            &section_lines,
+            &mut states,
+            &mut events,
+            &mut handlers,
+            &mut entry_exit,
+        );
+    }
+
+    // Compute state depths and set default parents from mermaid
+    compute_hierarchy(&mut states);
+
+    // Fill in inherited handlers for composite state children
+    fill_inherited_handlers(&mut handlers, &states);
+
+    // Fill dropped handlers for cells with no explicit or inherited handler
+    fill_dropped_handlers(&mut handlers, &states, &events);
+
+    // Build message sets from events
+    let mut sets: HashMap<String, Vec<String>> = HashMap::new();
+    for event in &events {
+        sets.entry(event.message_set.clone())
+            .or_default()
+            .push(event.variant.clone());
+    }
+    message_sets = sets
+        .into_iter()
+        .map(|(name, variants)| MessageSet { name, variants })
+        .collect();
+
+    BloxSpec {
+        name: name.to_string(),
+        states,
+        events,
+        handlers,
+        entry_exit,
+        message_sets,
+    }
+}
+
+fn parse_mermaid(content: &str, states: &mut Vec<State>) {
+    let mut current_composite: Option<String> = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("stateDiagram") {
+            continue;
+        }
+
+        if line.starts_with("state ") && line.contains("{") {
+            // Composite state: state Operating { ... }
+            let name = line
+                .trim_start_matches("state ")
+                .split('{')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !name.is_empty() && !states.iter().any(|s| s.name == name) {
+                states.push(State {
+                    name: name.clone(),
+                    kind: StateKind::Composite,
+                    parent: None,
+                    description: String::new(),
+                    depth: 0,
+                });
+                current_composite = Some(name);
+            }
+        } else if line == "}" {
+            current_composite = None;
+        } else if line.contains(" --> ") && !line.starts_with("[*]") {
+            // State transition: Active --> Paused
+            let parts: Vec<&str> = line.split("-->").collect();
+            if parts.len() == 2 {
+                let source = parts[0].trim().to_string();
+                let target_part = parts[1].trim();
+                let target = target_part
+                    .split(':')
+                    .next()
+                    .unwrap_or(target_part)
+                    .trim()
+                    .to_string();
+
+                for state_name in [source, target] {
+                    let clean_name = state_name.trim_start_matches("[*] --> ").trim().to_string();
+                    if !clean_name.is_empty()
+                        && !clean_name.starts_with("[*]")
+                        && !states.iter().any(|s| s.name == clean_name)
+                    {
+                        states.push(State {
+                            name: clean_name,
+                            kind: StateKind::Leaf,
+                            parent: current_composite.clone(),
+                            description: String::new(),
+                            depth: 0,
+                        });
+                    }
+                }
+            }
+        } else if !line.contains("-->")
+            && !line.contains("{")
+            && !line.starts_with("}")
+            && !line.is_empty()
+            && !line.starts_with("note")
+        {
+            // Maybe a standalone state name (child of composite)
+            let name = line.trim().to_string();
+            if !name.is_empty() && !states.iter().any(|s| s.name == name) {
+                states.push(State {
+                    name: name.clone(),
+                    kind: StateKind::Leaf,
+                    parent: current_composite.clone(),
+                    description: String::new(),
+                    depth: 0,
+                });
+            }
+        }
+    }
+}
+
+fn parse_tables_in_section(
+    section: &str,
+    lines: &[&str],
+    states: &mut Vec<State>,
+    events: &mut Vec<model::Event>,
+    handlers: &mut Vec<Handler>,
+    entry_exit: &mut HashMap<String, EntryExit>,
+) {
+    // Find table blocks (lines starting with |)
+    let mut current_table: Vec<Vec<String>> = Vec::new();
+    let mut in_table = false;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with('|') && !trimmed.starts_with("|>") {
+            // This is a table row
+            let cells: Vec<String> = trimmed
+                .trim_start_matches('|')
+                .trim_end_matches('|')
+                .split('|')
+                .map(|s| s.trim().to_string())
+                .collect();
+
+            // Skip separator rows (all dashes)
+            if cells.iter().all(|c| {
+                c.chars()
+                    .all(|ch| ch == '-' || ch == ' ' || ch == ':' || ch == '|')
+            }) {
+                continue;
+            }
+
+            current_table.push(cells);
+            in_table = true;
+        } else if in_table && !trimmed.starts_with('|') {
+            // Table ended
+            if !current_table.is_empty() {
+                parse_table(
+                    section,
+                    &current_table,
+                    states,
+                    events,
+                    handlers,
+                    entry_exit,
+                );
+            }
+            current_table.clear();
+            in_table = false;
+        }
+    }
+
+    // Handle table at end of section
+    if !current_table.is_empty() {
+        parse_table(
+            section,
+            &current_table,
+            states,
+            events,
+            handlers,
+            entry_exit,
+        );
+    }
+}
+
+fn parse_table(
+    section: &str,
+    rows: &[Vec<String>],
+    states: &mut Vec<State>,
+    events: &mut Vec<model::Event>,
+    handlers: &mut Vec<Handler>,
+    entry_exit: &mut HashMap<String, EntryExit>,
+) {
+    if rows.len() < 2 {
+        return;
+    }
+
+    match section.trim() {
+        "States" => {
+            for row in &rows[1..] {
+                if row.len() < 3 {
+                    continue;
+                }
+                let name = strip_backticks(&row[0]);
+                let kind_str = row.get(1).map(|s| s.trim().to_string()).unwrap_or_default();
+                let description = row.get(2).map(|s| s.trim().to_string()).unwrap_or_default();
+
+                if name.is_empty() || name == "State" || name.starts_with('[') {
+                    continue;
+                }
+
+                let kind = if kind_str.contains("composite") {
+                    StateKind::Composite
+                } else if kind_str.contains("terminal") {
+                    StateKind::Terminal
+                } else if kind_str.contains("error") {
+                    StateKind::Error
+                } else {
+                    StateKind::Leaf
+                };
+
+                // Update or insert
+                if let Some(existing) = states.iter_mut().find(|s| s.name == name) {
+                    existing.kind = kind;
+                    existing.description = description;
+                } else {
+                    states.push(State {
+                        name,
+                        kind,
+                        parent: None,
+                        description,
+                        depth: 0,
+                    });
+                }
+            }
+        }
+        "Events" => {
+            // Determine column layout from header
+            let headers: Vec<String> = rows[0].iter().map(|s| s.trim().to_lowercase()).collect();
+            let event_col = headers.iter().position(|h| h.contains("event"));
+            let handled_by_col = headers
+                .iter()
+                .position(|h| h.contains("handled") || h.contains("by"));
+            let guard_col = headers.iter().position(|h| {
+                h.contains("guard") || h.contains("outcome") || h.contains("reaction")
+            });
+            let side_effects_col = headers
+                .iter()
+                .position(|h| h.contains("side") || h.contains("effects"));
+
+            for row in &rows[1..] {
+                if row.len() < 2 {
+                    continue;
+                }
+
+                let event_str = event_col
+                    .map(|i| strip_backticks(&row[i]))
+                    .unwrap_or_default();
+                let handled_by = handled_by_col
+                    .map(|i| strip_backticks(&row[i]))
+                    .unwrap_or_default();
+                let guard_outcome = guard_col
+                    .map(|i| row[i].trim().to_string())
+                    .unwrap_or_default();
+                let side_effects = side_effects_col
+                    .map(|i| row[i].trim().to_string())
+                    .unwrap_or_default();
+
+                if event_str == "Event" || event_str.is_empty() || event_str == "any unhandled" {
+                    continue;
+                }
+
+                // Parse event: PingPongMsg::Pong(_) or CounterMsg::Tick
+                let (message_set, variant) = parse_event_str(&event_str);
+                let full_name = format!("{}::{}", message_set, variant);
+
+                if !events.iter().any(|e| e.full_name == full_name) {
+                    events.push(model::Event {
+                        message_set: message_set.clone(),
+                        variant: variant.clone(),
+                        full_name: full_name.clone(),
+                    });
+                }
+
+                // Create handler if handled by a specific state
+                if !handled_by.is_empty() && handled_by != "Handled by" {
+                    let state_name = if handled_by.contains("→") {
+                        // e.g., "Paused → bubbles → Operating"
+                        let first = handled_by.split("→").next().unwrap_or(&handled_by).trim();
+                        strip_backticks(first)
+                    } else {
+                        strip_backticks(&handled_by)
+                    };
+
+                    let (actions, guard, target, label) = parse_rule(&guard_outcome, &side_effects);
+
+                    if !handlers
+                        .iter()
+                        .any(|h| h.state == state_name && h.event == full_name)
+                    {
+                        handlers.push(Handler {
+                            state: state_name,
+                            event: full_name,
+                            label,
+                            actions,
+                            guard,
+                            target,
+                            source: HandlerSource::Explicit,
+                            on_entry: Vec::new(),
+                            on_exit: Vec::new(),
+                        });
+                    }
+                }
+            }
+        }
+        "Entry / Exit Actions" | "Entry/Exit Actions" | "Entry / Exit" => {
+            for row in &rows[1..] {
+                if row.len() < 3 {
+                    continue;
+                }
+                let state_name = strip_backticks(&row[0]);
+                let on_entry_str = row.get(1).map(|s| s.trim().to_string()).unwrap_or_default();
+                let on_exit_str = row.get(2).map(|s| s.trim().to_string()).unwrap_or_default();
+
+                if state_name == "State" || state_name.is_empty() || state_name.starts_with('[') {
+                    continue;
+                }
+
+                let on_entry = if on_entry_str.is_empty()
+                    || on_entry_str == "—"
+                    || on_entry_str == "_"
+                    || on_entry_str == "(none)"
+                {
+                    Vec::new()
+                } else {
+                    on_entry_str
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .collect()
+                };
+
+                let on_exit = if on_exit_str.is_empty()
+                    || on_exit_str == "—"
+                    || on_exit_str == "_"
+                    || on_exit_str == "(none)"
+                {
+                    Vec::new()
+                } else {
+                    on_exit_str
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .collect()
+                };
+
+                entry_exit.insert(state_name, EntryExit { on_entry, on_exit });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn strip_backticks(s: &str) -> String {
+    s.replace('`', "").trim().to_string()
+}
+
+fn parse_event_str(event_str: &str) -> (String, String) {
+    let cleaned = event_str.trim().trim_end_matches("(_)").trim().to_string();
+
+    if let Some(pos) = cleaned.find("::") {
+        let message_set = cleaned[..pos].trim().to_string();
+        let variant = cleaned[pos + 2..].trim().to_string();
+        // Remove any remaining parenthetical content
+        let variant = variant
+            .split('(')
+            .next()
+            .unwrap_or(&variant)
+            .trim()
+            .to_string();
+        (message_set, variant)
+    } else {
+        ("Unknown".to_string(), cleaned)
+    }
+}
+
+fn parse_rule(guard_outcome: &str, side_effects: &str) -> (Vec<String>, Guard, Target, String) {
+    let actions: Vec<String> = if side_effects.is_empty()
+        || side_effects == "none"
+        || side_effects == "none "
+        || side_effects == "—"
+    {
+        Vec::new()
+    } else {
+        side_effects
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    };
+
+    let guard = Guard {
+        description: guard_outcome.to_string(),
+        raw: guard_outcome.to_string(),
+        branches: Vec::new(),
+    };
+
+    let clean_guard = strip_backticks(guard_outcome);
+    let target = if clean_guard.contains("Stay") {
+        Target::Stay
+    } else if clean_guard.contains("Transition") {
+        // Extract state name from "Transition(StateName)"
+        if let Some(start) = clean_guard.find("Transition(") {
+            let after = &clean_guard[start + "Transition(".len()..];
+            let end = after.find(')').unwrap_or(after.len());
+            let state_name = after[..end].trim().to_string();
+            Target::Transition(state_name)
+        } else {
+            Target::Stay
+        }
+    } else if clean_guard.contains("reset") || clean_guard.contains("Reset") {
+        Target::Reset
+    } else {
+        Target::Stay
+    };
+
+    let label = if actions.is_empty() {
+        target.display()
+    } else {
+        // Use a short label: first action name or count
+        let action_label = if actions.len() == 1 {
+            actions[0].clone()
+        } else {
+            format!("{} actions", actions.len())
+        };
+        format!("{} → {}", action_label, target.display())
+    };
+
+    (actions, guard, target, label)
+}
+
+fn compute_hierarchy(states: &mut Vec<State>) {
+    // Set depth based on parent relationships
+    // Composite states are depth 0, their children are depth 1
+    for state in states.iter_mut() {
+        if state.parent.is_some() {
+            state.depth = 1;
+        }
+    }
+}
+
+fn fill_inherited_handlers(handlers: &mut Vec<Handler>, states: &[State]) {
+    // For each composite state, copy its handlers to children
+    let composites: Vec<&State> = states
+        .iter()
+        .filter(|s| matches!(s.kind, StateKind::Composite))
+        .collect();
+
+    for composite in &composites {
+        let composite_handlers: Vec<Handler> = handlers
+            .iter()
+            .filter(|h| h.state == composite.name)
+            .cloned()
+            .collect();
+
+        let children: Vec<&State> = states
+            .iter()
+            .filter(|s| s.parent.as_ref() == Some(&composite.name))
+            .collect();
+
+        for child in children {
+            for ch in &composite_handlers {
+                if !handlers
+                    .iter()
+                    .any(|h| h.state == child.name && h.event == ch.event)
+                {
+                    handlers.push(Handler {
+                        state: child.name.clone(),
+                        event: ch.event.clone(),
+                        label: format!("⬇️ {} ({})", ch.label, composite.name),
+                        actions: ch.actions.clone(),
+                        guard: ch.guard.clone(),
+                        target: ch.target.clone(),
+                        source: HandlerSource::Inherited(composite.name.clone()),
+                        on_entry: Vec::new(),
+                        on_exit: Vec::new(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn fill_dropped_handlers(handlers: &mut Vec<Handler>, states: &[State], events: &[model::Event]) {
+    // For leaf states that don't have a handler for an event, add a Dropped handler
+    let leaf_states: Vec<&State> = states.iter().filter(|s| s.kind.is_leaf()).collect();
+
+    for state in leaf_states {
+        for event in events {
+            if !handlers
+                .iter()
+                .any(|h| h.state == state.name && h.event == event.full_name)
+            {
+                handlers.push(Handler {
+                    state: state.name.clone(),
+                    event: event.full_name.clone(),
+                    label: "∅".to_string(),
+                    actions: Vec::new(),
+                    guard: Guard {
+                        description: "No handler — dropped".to_string(),
+                        raw: String::new(),
+                        branches: Vec::new(),
+                    },
+                    target: Target::Stay,
+                    source: HandlerSource::Dropped,
+                    on_entry: Vec::new(),
+                    on_exit: Vec::new(),
+                });
+            }
+        }
+    }
+}

--- a/tools/bloxide-viz-export/Cargo.toml
+++ b/tools/bloxide-viz-export/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bloxide-viz-export"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+syn = { version = "2", features = ["full", "visit"] }
+quote = "1"
+proc-macro2 = "1"
+walkdir = "2"
+
+[workspace]

--- a/tools/bloxide-viz-export/README.md
+++ b/tools/bloxide-viz-export/README.md
@@ -1,0 +1,42 @@
+# bloxide-viz-export
+
+CLI tool that scans a Bloxide workspace and exports visualization specs as JSON.
+
+## Purpose
+
+Instead of maintaining hand-written `.md` spec files that can drift from the actual Rust source code, this tool reads the **real** blox crate source (states, transitions, actions, messages, context) and generates a machine-readable JSON file that the [bloxide-visualizer](../bloxide-visualizer/) can load.
+
+## Usage
+
+```bash
+cd tools/bloxide-viz-export
+cargo run -- <path-to-bloxide-workspace> [output-dir]
+```
+
+Example against the main bloxide repo:
+
+```bash
+cargo run -- /home/bboganware/repos/bloxide
+```
+
+Output goes to `./bloxide-viz-output/` by default (or `[output-dir]` if provided). One `.json` file is written per discovered blox crate.
+
+## How it works
+
+1. **Scans** the workspace for crates containing a `src/spec.rs` with `MachineSpec for` and a `#[derive(StateTopology)]` state enum.
+2. **Parses** `src/spec.rs` with `syn` to extract:
+   - State topology (variants, composite/parent attributes)
+   - `StateFns` constants (on_entry, on_exit, transitions)
+   - `transitions!` macro invocations
+3. **Reads** `src/events.rs` for event/message definitions and `src/ctx.rs` for context fields.
+4. **Writes** a JSON file per blox.
+
+## JSON → Visualizer
+
+Open the [bloxide-visualizer](../bloxide-visualizer/) in a browser, click **Import .md / .json**, and select the generated `.json` file. The visualizer will render the heatmap directly from the source-derived data.
+
+## Known Limitations
+
+- Actions inside `transitions!` blocks are parsed heuristically; complex guard chains may not fully resolve to their correct targets.
+- Messages from external `*-messages` crates are referenced but not deeply parsed yet.
+- Action functions from `*-actions` crates are not yet extracted.

--- a/tools/bloxide-viz-export/src/lib.rs
+++ b/tools/bloxide-viz-export/src/lib.rs
@@ -1,0 +1,199 @@
+pub mod model;
+pub mod parser;
+
+use quote::ToTokens;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub use model::BloxSpec;
+
+/// Scan a workspace for blox crates and export them as `BloxSpec` structs.
+///
+/// Returns one `BloxSpec` per discovered blox crate.
+pub fn export_workspace(workspace_path: &Path) -> Result<Vec<BloxSpec>, String> {
+    let blox_crates = find_blox_crates(workspace_path);
+
+    if blox_crates.is_empty() {
+        return Err("No blox crates found.".to_string());
+    }
+
+    let mut specs = Vec::new();
+
+    for (name, crate_path) in &blox_crates {
+        let spec_path = crate_path.join("src/spec.rs");
+        let events_path = crate_path.join("src/events.rs");
+        let ctx_path = crate_path.join("src/ctx.rs");
+
+        let source = fs::read_to_string(&spec_path)
+            .map_err(|e| format!("could not read {}: {}", spec_path.display(), e))?;
+
+        if source.is_empty() {
+            continue;
+        }
+
+        let mut spec = parser::parse_blox_file(name, &crate_path.to_string_lossy(), &source)?;
+
+        // Try to parse events.rs for additional event/message info
+        if events_path.exists() {
+            if let Ok(events_source) = fs::read_to_string(&events_path) {
+                extract_messages_from_events(&mut spec, &events_source);
+            }
+        }
+
+        // Try to parse ctx.rs for context fields
+        if ctx_path.exists() {
+            if let Ok(ctx_source) = fs::read_to_string(&ctx_path) {
+                extract_context_fields(&mut spec, &ctx_source);
+            }
+        }
+
+        specs.push(spec);
+    }
+
+    Ok(specs)
+}
+
+/// Write exported specs as JSON files to the given output directory.
+pub fn write_specs_to_json(specs: &[BloxSpec], output_dir: &Path) -> Result<(), String> {
+    fs::create_dir_all(output_dir)
+        .map_err(|e| format!("Failed to create output directory: {}", e))?;
+
+    for spec in specs {
+        let output_path = output_dir.join(format!("{}.json", spec.name.to_lowercase()));
+        let json = serde_json::to_string_pretty(spec)
+            .map_err(|e| format!("Failed to serialize JSON: {}", e))?;
+        fs::write(&output_path, json)
+            .map_err(|e| format!("Failed to write {}: {}", output_path.display(), e))?;
+    }
+
+    Ok(())
+}
+
+fn find_blox_crates(workspace_path: &Path) -> Vec<(String, PathBuf)> {
+    let mut crates = Vec::new();
+
+    for entry in WalkDir::new(workspace_path)
+        .max_depth(6)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.file_name() == Some(std::ffi::OsStr::new("spec.rs")) {
+            let crate_path = path.parent().and_then(|p| p.parent());
+            if let Some(crate_path) = crate_path {
+                if let Ok(content) = fs::read_to_string(path) {
+                    if content.contains("MachineSpec for") && content.contains("StateTopology") {
+                        let blox_name = crate_path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|n| {
+                                let mut chars = n.chars();
+                                match chars.next() {
+                                    None => String::new(),
+                                    Some(first) => {
+                                        first.to_uppercase().collect::<String>() + chars.as_str()
+                                    }
+                                }
+                            })
+                            .unwrap_or_else(|| "Unknown".to_string());
+
+                        crates.push((blox_name, crate_path.to_path_buf()));
+                    }
+                }
+            }
+        }
+    }
+
+    crates.sort_by(|a, b| a.0.cmp(&b.0));
+    crates.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
+    crates
+}
+
+fn extract_messages_from_events(spec: &mut BloxSpec, source: &str) {
+    if let Ok(file) = syn::parse_file(source) {
+        for item in &file.items {
+            if let syn::Item::Enum(item_enum) = item {
+                let has_blox_event = item_enum.attrs.iter().any(|attr| {
+                    attr.path()
+                        .get_ident()
+                        .map(|i| i == "blox_event")
+                        .unwrap_or(false)
+                });
+
+                if has_blox_event {
+                    for variant in &item_enum.variants {
+                        let _variant_name = variant.ident.to_string();
+                        if let syn::Fields::Unnamed(fields) = &variant.fields {
+                            if let Some(field) = fields.unnamed.first() {
+                                let ty_str = format_type(&field.ty);
+                                if let Some(start) = ty_str.find('<') {
+                                    if let Some(end) = ty_str.rfind('>') {
+                                        let msg_type = &ty_str[start + 1..end];
+                                        if !spec.messages.iter().any(|m| m.enum_name == msg_type) {
+                                            spec.messages.push(model::MessageDef {
+                                                crate_name: "unknown".to_string(),
+                                                enum_name: msg_type.to_string(),
+                                                variants: Vec::new(),
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn extract_context_fields(spec: &mut BloxSpec, source: &str) {
+    if let Ok(file) = syn::parse_file(source) {
+        for item in &file.items {
+            if let syn::Item::Struct(item_struct) = item {
+                let has_blox_ctx = item_struct.attrs.iter().any(|attr| {
+                    attr.path()
+                        .get_ident()
+                        .map(|i| i == "derive")
+                        .unwrap_or(false)
+                        && attr.parse_args::<syn::Expr>().ok().map_or(false, |e| {
+                            e.to_token_stream().to_string().contains("BloxCtx")
+                        })
+                });
+
+                if has_blox_ctx {
+                    let mut fields = Vec::new();
+                    for field in &item_struct.fields {
+                        let name = field
+                            .ident
+                            .as_ref()
+                            .map(|i| i.to_string())
+                            .unwrap_or_default();
+                        let ty = format_type(&field.ty);
+                        let annotations: Vec<String> = field
+                            .attrs
+                            .iter()
+                            .map(|attr| attr.to_token_stream().to_string())
+                            .collect();
+
+                        fields.push(model::ContextField {
+                            name,
+                            ty,
+                            annotations,
+                        });
+                    }
+
+                    spec.context = Some(model::ContextDef {
+                        struct_name: item_struct.ident.to_string(),
+                        fields,
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn format_type(ty: &syn::Type) -> String {
+    ty.to_token_stream().to_string()
+}

--- a/tools/bloxide-viz-export/src/main.rs
+++ b/tools/bloxide-viz-export/src/main.rs
@@ -1,0 +1,55 @@
+use bloxide_viz_export::{export_workspace, write_specs_to_json};
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!(
+            "Usage: {} <path-to-bloxide-workspace> [output-dir]",
+            args[0]
+        );
+        eprintln!("");
+        eprintln!("Scans the workspace for blox crates and exports visualization JSON files.");
+        eprintln!("If output-dir is not provided, outputs to ./bloxide-viz-output/");
+        std::process::exit(1);
+    }
+
+    let workspace_path = Path::new(&args[1]);
+    let output_dir = args
+        .get(2)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("bloxide-viz-output"));
+
+    if !workspace_path.exists() {
+        eprintln!("Error: path '{}' does not exist", workspace_path.display());
+        std::process::exit(1);
+    }
+
+    println!("Scanning {} for blox crates...", workspace_path.display());
+
+    match export_workspace(workspace_path) {
+        Ok(specs) => {
+            println!("Found {} blox crate(s):", specs.len());
+            for spec in &specs {
+                println!("  - {}", spec.name);
+            }
+
+            if let Err(e) = write_specs_to_json(&specs, &output_dir) {
+                eprintln!("Error writing JSON: {}", e);
+                std::process::exit(1);
+            }
+
+            println!(
+                "\nDone. Exported {} blox spec(s) to {}",
+                specs.len(),
+                output_dir.display()
+            );
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/tools/bloxide-viz-export/src/model.rs
+++ b/tools/bloxide-viz-export/src/model.rs
@@ -1,0 +1,195 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BloxSpec {
+    pub name: String,
+    pub crate_path: String,
+    pub states: Vec<State>,
+    pub events: Vec<Event>,
+    pub handlers: Vec<Handler>,
+    pub entry_exit: HashMap<String, EntryExit>,
+    pub message_sets: Vec<MessageSet>,
+    pub messages: Vec<MessageDef>,
+    pub actions: Vec<ActionDef>,
+    pub context: Option<ContextDef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct State {
+    pub name: String,
+    pub kind: StateKind,
+    pub parent: Option<String>,
+    pub description: String,
+    pub depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StateKind {
+    Leaf,
+    Composite,
+    Terminal,
+    Error,
+}
+
+impl StateKind {
+    pub fn is_leaf(&self) -> bool {
+        matches!(
+            self,
+            StateKind::Leaf | StateKind::Terminal | StateKind::Error
+        )
+    }
+
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            StateKind::Leaf => "",
+            StateKind::Composite => "◇",
+            StateKind::Terminal => "◆",
+            StateKind::Error => "◈",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Event {
+    pub message_set: String,
+    pub variant: String,
+    pub full_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageSet {
+    pub name: String,
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Handler {
+    pub state: String,
+    pub event: String,
+    pub label: String,
+    pub actions: Vec<String>,
+    pub guard: Guard,
+    pub target: Target,
+    pub source: HandlerSource,
+    pub on_entry: Vec<String>,
+    pub on_exit: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum HandlerSource {
+    Explicit,
+    Inherited(String),
+    Dropped,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Target {
+    Stay,
+    Transition(String),
+    Reset,
+}
+
+impl Target {
+    pub fn display(&self) -> String {
+        match self {
+            Target::Stay => "stay".to_string(),
+            Target::Transition(s) => s.clone(),
+            Target::Reset => "reset".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Guard {
+    pub description: String,
+    pub raw: String,
+    pub branches: Vec<GuardBranch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GuardBranch {
+    pub condition: String,
+    pub target: Target,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntryExit {
+    pub on_entry: Vec<String>,
+    pub on_exit: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageDef {
+    pub crate_name: String,
+    pub enum_name: String,
+    pub variants: Vec<MessageVariant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageVariant {
+    pub name: String,
+    pub fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionDef {
+    pub crate_name: String,
+    pub function_name: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextDef {
+    pub struct_name: String,
+    pub fields: Vec<ContextField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextField {
+    pub name: String,
+    pub ty: String,
+    pub annotations: Vec<String>,
+}
+
+impl BloxSpec {
+    pub fn leaf_states(&self) -> Vec<&State> {
+        self.states.iter().filter(|s| s.kind.is_leaf()).collect()
+    }
+
+    pub fn composite_states(&self) -> Vec<&State> {
+        self.states
+            .iter()
+            .filter(|s| matches!(s.kind, StateKind::Composite))
+            .collect()
+    }
+
+    pub fn state_by_name(&self, name: &str) -> Option<&State> {
+        self.states.iter().find(|s| s.name == name)
+    }
+
+    pub fn handler_for(&self, state: &str, event: &str) -> Option<&Handler> {
+        self.handlers
+            .iter()
+            .find(|h| h.state == state && h.event == event)
+    }
+
+    pub fn events_for_set(&self, set_name: &str) -> Vec<&Event> {
+        self.events
+            .iter()
+            .filter(|e| e.message_set == set_name)
+            .collect()
+    }
+
+    pub fn message_sets_for_events(&self) -> Vec<MessageSet> {
+        let mut sets: HashMap<String, Vec<String>> = HashMap::new();
+        for event in &self.events {
+            sets.entry(event.message_set.clone())
+                .or_default()
+                .push(event.variant.clone());
+        }
+        sets.into_iter()
+            .map(|(name, variants)| MessageSet { name, variants })
+            .collect()
+    }
+}

--- a/tools/bloxide-viz-export/src/parser.rs
+++ b/tools/bloxide-viz-export/src/parser.rs
@@ -1,0 +1,762 @@
+use proc_macro2::{Delimiter, Ident, TokenStream, TokenTree};
+use std::collections::HashMap;
+use syn::visit::Visit;
+use syn::{Expr, ExprArray, ItemConst, ItemEnum, Variant};
+
+use crate::model::*;
+
+pub struct BloxExtractor {
+    pub spec: BloxSpec,
+    pub state_enum_name: Option<String>,
+    pub current_state_fns: Option<String>,
+}
+
+impl BloxExtractor {
+    pub fn new(name: &str, crate_path: &str) -> Self {
+        Self {
+            spec: BloxSpec {
+                name: name.to_string(),
+                crate_path: crate_path.to_string(),
+                states: Vec::new(),
+                events: Vec::new(),
+                handlers: Vec::new(),
+                entry_exit: HashMap::new(),
+                message_sets: Vec::new(),
+                messages: Vec::new(),
+                actions: Vec::new(),
+                context: None,
+            },
+            state_enum_name: None,
+            current_state_fns: None,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for BloxExtractor {
+    fn visit_item_enum(&mut self, node: &'ast ItemEnum) {
+        let has_state_topology = node.attrs.iter().any(|attr| {
+            attr.path().is_ident("derive")
+                && attr
+                    .parse_args::<TokenStream>()
+                    .ok()
+                    .map_or(false, |ts| ts.to_string().contains("StateTopology"))
+        });
+
+        if has_state_topology {
+            self.state_enum_name = Some(node.ident.to_string());
+            for variant in &node.variants {
+                self.extract_state(variant);
+            }
+        }
+
+        syn::visit::visit_item_enum(self, node);
+    }
+
+    fn visit_item_const(&mut self, node: &'ast ItemConst) {
+        // Look for StateFns constants like ACTIVE_FNS, PAUSED_FNS, etc.
+        let name = node.ident.to_string();
+        if name.ends_with("_FNS") {
+            let state_name = name.trim_end_matches("_FNS");
+            self.current_state_fns = Some(state_name.to_string());
+            self.extract_state_fns(&node.expr);
+            self.current_state_fns = None;
+        }
+
+        syn::visit::visit_item_const(self, node);
+    }
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        // Also visit associated constants inside impl blocks
+        for item in &node.items {
+            if let syn::ImplItem::Const(const_item) = item {
+                let name = const_item.ident.to_string();
+                if name.ends_with("_FNS") {
+                    let state_name = name.trim_end_matches("_FNS");
+                    self.current_state_fns = Some(state_name.to_string());
+                    self.extract_state_fns(&const_item.expr);
+                    self.current_state_fns = None;
+                }
+            }
+        }
+
+        syn::visit::visit_item_impl(self, node);
+    }
+}
+
+impl BloxExtractor {
+    fn extract_state(&mut self, variant: &Variant) {
+        let name = variant.ident.to_string();
+
+        let is_composite = variant
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("composite"));
+        let parent = variant.attrs.iter().find_map(|attr| {
+            if attr.path().is_ident("parent") {
+                attr.parse_args::<Ident>().ok().map(|i| i.to_string())
+            } else {
+                None
+            }
+        });
+
+        let kind = if is_composite {
+            StateKind::Composite
+        } else {
+            StateKind::Leaf
+        };
+
+        // Don't duplicate
+        if !self.spec.states.iter().any(|s| s.name == name) {
+            self.spec.states.push(State {
+                name,
+                kind,
+                parent,
+                description: String::new(),
+                depth: 0,
+            });
+        }
+    }
+
+    fn resolve_state_name(&self, fns_name: &str) -> String {
+        // Try to match the UPPER_SNAKE_CASE _FNS suffix to a PascalCase state name
+        let candidates: Vec<&str> = self.spec.states.iter().map(|s| s.name.as_str()).collect();
+        let fns_lower = fns_name.to_lowercase();
+
+        for candidate in &candidates {
+            if candidate.to_lowercase() == fns_lower {
+                return candidate.to_string();
+            }
+        }
+
+        // Fallback: try to convert the _FNS name to PascalCase
+        // e.g., "ACTIVE" -> "Active"
+        fns_name
+            .split('_')
+            .map(|word| {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => {
+                        first.to_uppercase().collect::<String>()
+                            + chars.as_str().to_lowercase().as_str()
+                    }
+                }
+            })
+            .collect()
+    }
+
+    fn extract_state_fns(&mut self, expr: &Expr) {
+        let state_name = match &self.current_state_fns {
+            Some(n) => self.resolve_state_name(n),
+            None => return,
+        };
+
+        // The expr should be a struct literal: StateFns { on_entry: &[...], on_exit: &[...], transitions: transitions![...] }
+        if let Expr::Struct(expr_struct) = expr {
+            for field in &expr_struct.fields {
+                let member_name = match &field.member {
+                    syn::Member::Named(ident) => ident.to_string(),
+                    _ => continue,
+                };
+
+                match member_name.as_str() {
+                    "on_entry" => {
+                        if let Ok(actions) = parse_action_array(&field.expr) {
+                            let entry_exit = self
+                                .spec
+                                .entry_exit
+                                .entry(state_name.clone())
+                                .or_insert_with(|| EntryExit {
+                                    on_entry: Vec::new(),
+                                    on_exit: Vec::new(),
+                                });
+                            entry_exit.on_entry = actions;
+                        }
+                    }
+                    "on_exit" => {
+                        if let Ok(actions) = parse_action_array(&field.expr) {
+                            let entry_exit = self
+                                .spec
+                                .entry_exit
+                                .entry(state_name.clone())
+                                .or_insert_with(|| EntryExit {
+                                    on_entry: Vec::new(),
+                                    on_exit: Vec::new(),
+                                });
+                            entry_exit.on_exit = actions;
+                        }
+                    }
+                    "transitions" => {
+                        self.extract_transitions(&field.expr, &state_name);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn extract_transitions(&mut self, expr: &Expr, state_name: &str) {
+        match expr {
+            Expr::Macro(mac) => {
+                if mac.mac.path.is_ident("transitions")
+                    || mac
+                        .mac
+                        .path
+                        .get_ident()
+                        .map(|i| i.to_string() == "transitions")
+                        .unwrap_or(false)
+                {
+                    let tokens = mac.mac.tokens.clone();
+                    if let Ok(rules) = parse_transition_rules(&tokens) {
+                        for rule in rules {
+                            self.add_handler(state_name, rule);
+                        }
+                    }
+                }
+            }
+            Expr::Reference(expr_ref) => {
+                // Handle &[...] array of rules (for manually constructed transitions)
+                self.extract_transitions(&expr_ref.expr, state_name);
+            }
+            Expr::Array(_expr_array) => {
+                // Empty array: &[]
+            }
+            _ => {}
+        }
+    }
+
+    fn add_handler(&mut self, state_name: &str, rule: TransitionRule) {
+        let full_event = rule.event_pattern.clone();
+        let (message_set, variant) = parse_event_pattern(&rule.event_pattern);
+
+        // Add event if not already present
+        if !self.spec.events.iter().any(|e| e.full_name == full_event) {
+            self.spec.events.push(Event {
+                message_set: message_set.clone(),
+                variant: variant.clone(),
+                full_name: full_event.clone(),
+            });
+        }
+
+        // Determine target
+        let target = if rule.target.is_empty() || rule.target == "stay" {
+            Target::Stay
+        } else if rule.target == "reset" || rule.target == "Reset" {
+            Target::Reset
+        } else {
+            Target::Transition(rule.target.clone())
+        };
+
+        let label = if rule.actions.is_empty() {
+            target.display()
+        } else {
+            let action_label = if rule.actions.len() == 1 {
+                rule.actions[0].clone()
+            } else {
+                format!("{} actions", rule.actions.len())
+            };
+            format!("{} → {}", action_label, target.display())
+        };
+
+        let guard = Guard {
+            description: rule.guard_description.clone(),
+            raw: rule.guard_raw.clone(),
+            branches: rule.guard_branches.clone(),
+        };
+
+        self.spec.handlers.push(Handler {
+            state: state_name.to_string(),
+            event: full_event,
+            label,
+            actions: rule.actions,
+            guard,
+            target,
+            source: HandlerSource::Explicit,
+            on_entry: Vec::new(),
+            on_exit: Vec::new(),
+        });
+    }
+}
+
+#[derive(Debug)]
+struct TransitionRule {
+    event_pattern: String,
+    actions: Vec<String>,
+    guard_description: String,
+    guard_raw: String,
+    guard_branches: Vec<GuardBranch>,
+    target: String,
+}
+
+fn parse_action_array(expr: &Expr) -> Result<Vec<String>, ()> {
+    match expr {
+        Expr::Reference(expr_ref) => parse_action_array(&expr_ref.expr),
+        Expr::Array(ExprArray { elems, .. }) => {
+            let mut actions = Vec::new();
+            for elem in elems {
+                if let Expr::Path(path) = elem {
+                    actions.push(
+                        path.path
+                            .segments
+                            .last()
+                            .map(|s| s.ident.to_string())
+                            .unwrap_or_default(),
+                    );
+                } else if let Expr::Call(call) = elem {
+                    if let Expr::Path(path) = &*call.func {
+                        actions.push(
+                            path.path
+                                .segments
+                                .last()
+                                .map(|s| s.ident.to_string())
+                                .unwrap_or_default(),
+                        );
+                    }
+                }
+            }
+            Ok(actions)
+        }
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn parse_transition_rules(tokens: &TokenStream) -> Result<Vec<TransitionRule>, String> {
+    let mut rules = Vec::new();
+    let mut arm_tokens = Vec::new();
+
+    for tt in tokens.clone().into_iter() {
+        match &tt {
+            TokenTree::Punct(p) if p.as_char() == ',' => {
+                if !arm_tokens.is_empty() {
+                    let arm_stream: TokenStream = arm_tokens.drain(..).collect();
+                    if let Ok(rule) = parse_transition_arm(arm_stream) {
+                        rules.push(rule);
+                    }
+                }
+            }
+            TokenTree::Group(_g) => {
+                // Groups are opaque at this level of token stream iteration.
+                // The comma we want to split on is always a top-level punct token.
+                arm_tokens.push(tt.clone());
+            }
+            _ => arm_tokens.push(tt.clone()),
+        }
+    }
+
+    // Last arm (no trailing comma)
+    if !arm_tokens.is_empty() {
+        let arm_stream: TokenStream = arm_tokens.drain(..).collect();
+        if let Ok(rule) = parse_transition_arm(arm_stream) {
+            rules.push(rule);
+        }
+    }
+
+    Ok(rules)
+}
+
+fn parse_transition_arm(tokens: TokenStream) -> Result<TransitionRule, String> {
+    let tokens: Vec<TokenTree> = tokens.into_iter().collect();
+
+    // Find the => separator
+    let mut arrow_pos = None;
+    for (i, tt) in tokens.iter().enumerate() {
+        if let TokenTree::Punct(p) = tt {
+            if p.as_char() == '=' && i + 1 < tokens.len() {
+                if let TokenTree::Punct(p2) = &tokens[i + 1] {
+                    if p2.as_char() == '>' {
+                        arrow_pos = Some(i);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let arrow_pos = arrow_pos.ok_or("No => found in transition arm")?;
+
+    // Pattern is everything before =>
+    let pattern_tokens: TokenStream = tokens[..arrow_pos].iter().cloned().collect();
+    let pattern = pattern_tokens.to_string().trim().to_string();
+
+    // Body is everything after => (skip the >)
+    let body_tokens: TokenStream = tokens[arrow_pos + 2..].iter().cloned().collect();
+
+    // Check if body is just "stay" or "transition StateName"
+    let body_str = body_tokens.to_string().trim().to_string();
+
+    if body_str == "stay" || body_str.starts_with("stay ") {
+        return Ok(TransitionRule {
+            event_pattern: pattern,
+            actions: Vec::new(),
+            guard_description: "Stay".to_string(),
+            guard_raw: body_str.clone(),
+            guard_branches: vec![GuardBranch {
+                condition: "_".to_string(),
+                target: Target::Stay,
+            }],
+            target: "stay".to_string(),
+        });
+    }
+
+    if body_str.starts_with("transition ") {
+        let target = body_str
+            .trim_start_matches("transition ")
+            .trim()
+            .to_string();
+        return Ok(TransitionRule {
+            event_pattern: pattern,
+            actions: Vec::new(),
+            guard_description: format!("Transition({})", target),
+            guard_raw: body_str.clone(),
+            guard_branches: vec![GuardBranch {
+                condition: "_".to_string(),
+                target: Target::Transition(target.clone()),
+            }],
+            target,
+        });
+    }
+
+    // Parse full body: { actions [...] guard(ctx, results) { ... } }
+    let mut actions = Vec::new();
+    let mut guard_desc = String::new();
+    let mut guard_branches = Vec::new();
+    let mut target = String::new();
+
+    // Simple token-based parsing of the body
+    let mut in_actions = false;
+    let mut in_guard = false;
+    let mut in_guard_chain = false;
+    let mut depth: usize = 0;
+    let mut current_token = String::new();
+
+    for tt in body_tokens.into_iter() {
+        match tt {
+            TokenTree::Ident(ident) => {
+                let s = ident.to_string();
+                if s == "actions" && !in_actions && !in_guard {
+                    in_actions = true;
+                } else if s == "guard" && !in_guard {
+                    in_guard = true;
+                } else if in_actions && depth == 1 {
+                    if s == "Self" {
+                        current_token = "Self::".to_string();
+                    } else {
+                        if !current_token.is_empty() {
+                            current_token.push_str(&s);
+                        } else {
+                            current_token = s;
+                        }
+                    }
+                } else if in_guard_chain && depth == 1 {
+                    // Inside guard chain body
+                    if s == "stay" && !target.is_empty() {
+                        // This is a target in guard chain
+                    }
+                } else if in_guard {
+                    // skip guard args
+                }
+            }
+            TokenTree::Punct(p) => {
+                let ch = p.as_char();
+                if in_actions && depth == 1 {
+                    if ch == ':' && current_token == "Self" {
+                        current_token.push_str("::");
+                    } else if ch == ',' && !current_token.is_empty() {
+                        actions.push(current_token.trim().to_string());
+                        current_token.clear();
+                    } else if ch == ']' {
+                        if !current_token.is_empty() {
+                            actions.push(current_token.trim().to_string());
+                            current_token.clear();
+                        }
+                        in_actions = false;
+                    }
+                } else if in_guard {
+                    if ch == ')' && depth == 1 {
+                        // End of guard args
+                    }
+                } else if in_guard_chain {
+                    if ch == '=' && depth == 1 {
+                        // => in guard chain
+                    } else if ch == '>' {
+                        // part of =>
+                    }
+                }
+            }
+            TokenTree::Group(g) => {
+                match g.delimiter() {
+                    Delimiter::Bracket => {
+                        if in_actions {
+                            // Parse the group content as actions
+                            let group_str = g.stream().to_string();
+                            for action in group_str.split(',') {
+                                let a = action.trim().to_string();
+                                if !a.is_empty() {
+                                    actions.push(a);
+                                }
+                            }
+                            in_actions = false;
+                        }
+                    }
+                    Delimiter::Brace => {
+                        if in_guard {
+                            depth += 1;
+                            if depth == 1 {
+                                in_guard_chain = true;
+                                guard_desc = g.stream().to_string();
+                                // Parse guard branches
+                                guard_branches = parse_guard_chain(&g.stream());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            TokenTree::Literal(lit) => {
+                if in_guard_chain && depth == 1 {
+                    let s = lit.to_string();
+                    if target.is_empty() {
+                        target = s.trim().to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    if target.is_empty() {
+        target = "stay".to_string();
+    }
+
+    Ok(TransitionRule {
+        event_pattern: pattern,
+        actions,
+        guard_description: if guard_desc.is_empty() {
+            target.clone()
+        } else {
+            guard_desc
+        },
+        guard_raw: body_str,
+        guard_branches,
+        target,
+    })
+}
+
+fn parse_guard_chain(tokens: &TokenStream) -> Vec<GuardBranch> {
+    let mut branches = Vec::new();
+    let tokens: Vec<TokenTree> = tokens.clone().into_iter().collect();
+
+    let mut i = 0;
+    while i < tokens.len() {
+        // Look for pattern => target,
+        let mut cond_tokens = Vec::new();
+        while i < tokens.len() {
+            if let TokenTree::Punct(p) = &tokens[i] {
+                if p.as_char() == '=' {
+                    // Check if next is >
+                    if i + 1 < tokens.len() {
+                        if let TokenTree::Punct(p2) = &tokens[i + 1] {
+                            if p2.as_char() == '>' {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            cond_tokens.push(tokens[i].clone());
+            i += 1;
+        }
+
+        if i >= tokens.len() {
+            break;
+        }
+
+        // Skip =>
+        i += 2;
+
+        // Read target
+        let mut target_tokens = Vec::new();
+        while i < tokens.len() {
+            if let TokenTree::Punct(p) = &tokens[i] {
+                if p.as_char() == ',' {
+                    i += 1;
+                    break;
+                }
+            }
+            target_tokens.push(tokens[i].clone());
+            i += 1;
+        }
+
+        let condition = cond_tokens.into_iter().collect::<TokenStream>().to_string();
+        let target_str = target_tokens
+            .into_iter()
+            .collect::<TokenStream>()
+            .to_string();
+
+        let target = if target_str.trim() == "stay" {
+            Target::Stay
+        } else if target_str.trim().starts_with("Transition") {
+            if let Some(inner) = extract_transition_target(&target_str) {
+                Target::Transition(inner)
+            } else {
+                Target::Stay
+            }
+        } else {
+            Target::Transition(target_str.trim().to_string())
+        };
+
+        branches.push(GuardBranch {
+            condition: condition.trim().to_string(),
+            target,
+        });
+    }
+
+    branches
+}
+
+fn extract_transition_target(s: &str) -> Option<String> {
+    // Extract StateName from "Transition(StateName)" or "Transition(StateName { ... })"
+    let s = s.trim();
+    if s.starts_with("Transition(") {
+        let inner = &s["Transition(".len()..];
+        if let Some(end) = inner.rfind(')') {
+            let state = inner[..end].trim().to_string();
+            // Take just the first token (state name) if there are braces
+            Some(state.split_whitespace().next()?.to_string())
+        } else {
+            None
+        }
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn parse_event_pattern(pattern: &str) -> (String, String) {
+    let pattern = pattern.trim();
+    // Remove trailing parenthetical content like (_)
+    let clean = if let Some(pos) = pattern.find('(') {
+        &pattern[..pos]
+    } else {
+        pattern
+    };
+
+    if let Some(pos) = clean.find("::") {
+        let message_set = clean[..pos].trim().to_string();
+        let variant = clean[pos + 2..].trim().to_string();
+        (message_set, variant)
+    } else {
+        ("Unknown".to_string(), clean.to_string())
+    }
+}
+
+/// Parse a source file and extract blox metadata.
+pub fn parse_blox_file(name: &str, crate_path: &str, source: &str) -> Result<BloxSpec, String> {
+    let file = syn::parse_file(source).map_err(|e| e.to_string())?;
+
+    let mut extractor = BloxExtractor::new(name, crate_path);
+    syn::visit::visit_file(&mut extractor, &file);
+
+    // Compute hierarchy depths
+    compute_hierarchy(&mut extractor.spec.states);
+
+    // Fill inherited handlers for composite state children
+    fill_inherited_handlers(&mut extractor.spec.handlers, &extractor.spec.states);
+
+    // Fill dropped handlers
+    fill_dropped_handlers(
+        &mut extractor.spec.handlers,
+        &extractor.spec.states,
+        &extractor.spec.events,
+    );
+
+    // Build message sets from events
+    let mut sets: HashMap<String, Vec<String>> = HashMap::new();
+    for event in &extractor.spec.events {
+        sets.entry(event.message_set.clone())
+            .or_default()
+            .push(event.variant.clone());
+    }
+    extractor.spec.message_sets = sets
+        .into_iter()
+        .map(|(name, variants)| MessageSet { name, variants })
+        .collect();
+
+    Ok(extractor.spec)
+}
+
+fn compute_hierarchy(states: &mut Vec<State>) {
+    for state in states.iter_mut() {
+        if state.parent.is_some() {
+            state.depth = 1;
+        }
+    }
+}
+
+fn fill_inherited_handlers(handlers: &mut Vec<Handler>, states: &[State]) {
+    let composites: Vec<&State> = states
+        .iter()
+        .filter(|s| matches!(s.kind, StateKind::Composite))
+        .collect();
+
+    for composite in &composites {
+        let composite_handlers: Vec<Handler> = handlers
+            .iter()
+            .filter(|h| h.state == composite.name)
+            .cloned()
+            .collect();
+
+        let children: Vec<&State> = states
+            .iter()
+            .filter(|s| s.parent.as_ref() == Some(&composite.name))
+            .collect();
+
+        for child in children {
+            for ch in &composite_handlers {
+                if !handlers
+                    .iter()
+                    .any(|h| h.state == child.name && h.event == ch.event)
+                {
+                    handlers.push(Handler {
+                        state: child.name.clone(),
+                        event: ch.event.clone(),
+                        label: format!("⬇️ {} ({})", ch.label, composite.name),
+                        actions: ch.actions.clone(),
+                        guard: ch.guard.clone(),
+                        target: ch.target.clone(),
+                        source: HandlerSource::Inherited(composite.name.clone()),
+                        on_entry: Vec::new(),
+                        on_exit: Vec::new(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn fill_dropped_handlers(handlers: &mut Vec<Handler>, states: &[State], events: &[Event]) {
+    let leaf_states: Vec<&State> = states.iter().filter(|s| s.kind.is_leaf()).collect();
+
+    for state in leaf_states {
+        for event in events {
+            if !handlers
+                .iter()
+                .any(|h| h.state == state.name && h.event == event.full_name)
+            {
+                handlers.push(Handler {
+                    state: state.name.clone(),
+                    event: event.full_name.clone(),
+                    label: "∅".to_string(),
+                    actions: Vec::new(),
+                    guard: Guard {
+                        description: "No handler — dropped".to_string(),
+                        raw: String::new(),
+                        branches: Vec::new(),
+                    },
+                    target: Target::Stay,
+                    source: HandlerSource::Dropped,
+                    on_entry: Vec::new(),
+                    on_exit: Vec::new(),
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces two new tools under `tools/`:

## `bloxide-viz-export` — Source-to-JSON exporter

A library + CLI that parses **actual blox crate source code** and extracts machine-readable spec metadata:
- Scans a workspace for crates with `MachineSpec` + `StateTopology`
- Parses `spec.rs`, `events.rs`, `ctx.rs` via `syn`
- Extracts states, transitions, actions, guards, messages, context fields
- Outputs one `.json` file per blox (or returns `Vec<BloxSpec>` via library API)

**Usage:**
```bash
cd tools/bloxide-viz-export
cargo run -- /path/to/bloxide/workspace
```

## `bloxide-visualizer` — Dioxus 0.7.6 fullstack web UI

A browser-based heatmap visualizer that renders state × event handler grids:
- **Built-in specs** loaded from `spec/bloxes/*.md` (Counter, Ping, Pong, Pool, Worker)
- **Workspace scanner** — type a path, click "Scan workspace", server calls `bloxide-viz-export` and returns specs
- **File import** — drag-and-drop `.md` or `.json` files
- **Heatmap grid** — color-coded cells: explicit (blue), inherited (yellow), dropped (gray)
- **Side panel** — click any cell to see state kind, actions, guard, target, entry/exit handlers

**Serve locally:**
```bash
cd tools/bloxide-visualizer
./serve.sh   # dx serve --release --debug-symbols false
```

## Architecture highlights
- `bloxide-viz-export` is a pure library (no runtime deps) so the visualizer server can call it
- Server-only deps (`syn`, `walkdir`, `tokio` transitives) are gated behind `cfg(feature = "server")`
- `--debug-symbols false` avoids `wasm-opt` DWARF crashes on the WASM client bundle

## Tests
- `bloxide-visualizer`: 3 tests pass (markdown parse, JSON round-trip)
- `bloxide-viz-export`: compiles clean as lib + binary