### PR TITLE
fix: add copyright headers, local CI script, and workflow path fixes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,6 +10,7 @@ on:
       - "crates/**"
       - "runtimes/**"
       - "examples/**"
+      - "tools/**"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
@@ -27,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check Copyright Compliance
         run: |
-          INCORRECT_COPYRIGHT=$(find . -name '*.rs' -not -path "./target/*" -o -name 'Cargo.toml' -not -path "./target/*" \
+          INCORRECT_COPYRIGHT=$(find . \( -name '*.rs' -o -name 'Cargo.toml' \) -not -path '*/target/*' \
           | xargs grep -LE '(#|//) Copyright 202[0-9] Bloxide, all rights reserved')
           if [ -n "$INCORRECT_COPYRIGHT" ]; then
             echo "Incorrect copyright notice found:"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,124 @@
+# Copyright 2025 Bloxide, all rights reserved
+#!/usr/bin/env bash
+# Run CI checks locally, directly on the host machine.
+# This executes the same commands as .github/workflows/lint-and-test.yml,
+# but without Docker overhead. Much faster than act for routine pre-PR checks.
+#
+# Usage:
+#   ./scripts/ci.sh              # run all checks
+#   ./scripts/ci.sh lint         # run only lint (build, check, fmt, clippy)
+#   ./scripts/ci.sh test         # run only tests
+#   ./scripts/ci.sh copyright    # run only copyright check
+#   ./scripts/ci.sh docs         # run only docs build
+#
+# Requirements:
+#   - stable Rust toolchain (rustup, cargo, rustc)
+#   - clippy component installed
+#   - riscv32imc-unknown-none-elf target installed (for embassy checks)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+run_step() {
+    local name="$1"
+    shift
+    echo ""
+    echo "========================================"
+    echo "  ${name}"
+    echo "========================================"
+    if "$@"; then
+        echo -e "${GREEN}✓ ${name} passed${NC}"
+    else
+        echo -e "${RED}✗ ${name} failed${NC}"
+        exit 1
+    fi
+}
+
+check_copyright() {
+    INCORRECT_COPYRIGHT=$(find . \( -name '*.rs' -o -name 'Cargo.toml' \) -not -path '*/target/*' \
+        | xargs grep -LE '(#|//) Copyright 202[0-9] Bloxide, all rights reserved' || true)
+    if [ -n "$INCORRECT_COPYRIGHT" ]; then
+        echo "Incorrect copyright notice found:"
+        echo "$INCORRECT_COPYRIGHT" | tr ' ' '\n'
+        return 1
+    fi
+    echo "All source files have correct copyright notices."
+}
+
+run_lint() {
+    run_step "Cargo Build (default features)" cargo build
+
+    run_step "Cargo Check (bloxide-core no-default-features)" \
+        cargo check -p bloxide-core --no-default-features
+
+    run_step "Cargo Check (bloxide-core alloc)" \
+        cargo check -p bloxide-core --no-default-features --features alloc
+
+    run_step "Cargo Check (bloxide-core std)" \
+        cargo check -p bloxide-core --features std
+
+    run_step "Cargo Check (bloxide-timer riscv32imc)" \
+        cargo check -p bloxide-timer --target riscv32imc-unknown-none-elf
+
+    run_step "Cargo Check (ping-pong-messages no-default-features)" \
+        cargo check -p ping-pong-messages --no-default-features
+
+    run_step "Cargo Format Check" cargo fmt -- --check
+
+    run_step "Cargo Clippy" cargo clippy --all-targets -- -W warnings -D warnings
+}
+
+run_tests() {
+    run_step "Cargo Test (bloxide-core std)" \
+        cargo test -p bloxide-core --features std
+
+    run_step "Cargo Test (workspace default)" \
+        cargo test
+}
+
+run_docs() {
+    run_step "Cargo Doc Build" \
+        sh -c 'RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps'
+}
+
+# Parse arguments
+MODE="${1:-all}"
+
+case "$MODE" in
+    all)
+        run_step "Copyright Compliance" check_copyright
+        run_lint
+        run_tests
+        run_docs
+        echo ""
+        echo "========================================"
+        echo -e "${GREEN}All CI checks passed!${NC}"
+        echo "========================================"
+        ;;
+    lint)
+        run_lint
+        ;;
+    test)
+        run_tests
+        ;;
+    copyright)
+        run_step "Copyright Compliance" check_copyright
+        ;;
+    docs)
+        run_docs
+        ;;
+    *)
+        echo "Usage: $0 [all|lint|test|copyright|docs]"
+        exit 1
+        ;;
+esac

--- a/tools/bloxide-visualizer/Cargo.toml
+++ b/tools/bloxide-visualizer/Cargo.toml
@@ -1,3 +1,4 @@
+# Copyright 2025 Bloxide, all rights reserved
 [package]
 name = "bloxide-visualizer"
 version = "0.1.0"

--- a/tools/bloxide-visualizer/src/data.rs
+++ b/tools/bloxide-visualizer/src/data.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use crate::model::BloxSpec;
 use crate::parser::parse_spec;
 

--- a/tools/bloxide-visualizer/src/main.rs
+++ b/tools/bloxide-visualizer/src/main.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 mod data;
 mod model;
 mod parser;

--- a/tools/bloxide-visualizer/src/model.rs
+++ b/tools/bloxide-visualizer/src/model.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/tools/bloxide-visualizer/src/parser.rs
+++ b/tools/bloxide-visualizer/src/parser.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use crate::model;
 use crate::model::*;
 use std::collections::HashMap;

--- a/tools/bloxide-viz-export/Cargo.toml
+++ b/tools/bloxide-viz-export/Cargo.toml
@@ -1,3 +1,4 @@
+# Copyright 2025 Bloxide, all rights reserved
 [package]
 name = "bloxide-viz-export"
 version = "0.1.0"

--- a/tools/bloxide-viz-export/src/lib.rs
+++ b/tools/bloxide-viz-export/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 pub mod model;
 pub mod parser;
 

--- a/tools/bloxide-viz-export/src/main.rs
+++ b/tools/bloxide-viz-export/src/main.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use bloxide_viz_export::{export_workspace, write_specs_to_json};
 use std::env;
 use std::path::Path;

--- a/tools/bloxide-viz-export/src/model.rs
+++ b/tools/bloxide-viz-export/src/model.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/tools/bloxide-viz-export/src/parser.rs
+++ b/tools/bloxide-viz-export/src/parser.rs
@@ -1,3 +1,4 @@
+// Copyright 2025 Bloxide, all rights reserved
 use proc_macro2::{Delimiter, Ident, TokenStream, TokenTree};
 use std::collections::HashMap;
 use syn::visit::Visit;


### PR DESCRIPTION
Fixes CI issues discovered after the visualizer tools PR was merged:

## Changes

- **Copyright headers**: Added to all new `.rs` and `Cargo.toml` files under `tools/`
- **CI workflow fix**: The `find` command in `.github/workflows/lint-and-test.yml` now properly excludes `*/target/*` (not just `./target/*`), so nested workspace target directories don't match
- **CI path triggers**: Added `tools/**` to the PR trigger paths so changes to visualizer tools actually run CI
- **Local CI script**: Added `scripts/ci.sh` that runs the same checks as GitHub Actions directly on the host machine (much faster than Docker-based act for routine pre-PR validation)

## Usage

```bash
# Run all checks locally (same as GitHub Actions)
./scripts/ci.sh

# Run only a specific job
./scripts/ci.sh lint
./scripts/ci.sh test
./scripts/ci.sh copyright
./scripts/ci.sh docs
```

## Verification

All checks pass locally:
```
$ ./scripts/ci.sh all
✓ Copyright Compliance passed
✓ Cargo Build passed
✓ Cargo Check (bloxide-core no-default-features) passed
✓ Cargo Check (bloxide-core alloc) passed
✓ Cargo Check (bloxide-core std) passed
✓ Cargo Check (bloxide-timer riscv32imc) passed
✓ Cargo Check (ping-pong-messages no-default-features) passed
✓ Cargo Format Check passed
✓ Cargo Clippy passed
✓ Cargo Test (bloxide-core std) passed
✓ Cargo Test (workspace default) passed
✓ Cargo Doc Build passed
```